### PR TITLE
add docker compose build target

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,1 +1,2 @@
 /agentpen
+/.cache/

--- a/README.md
+++ b/README.md
@@ -29,9 +29,11 @@ With Nix (recommended, no host pollution):
 
 With Docker (works anywhere `docker compose` does, pins the Go toolchain):
 
-    docker compose run --rm build
+    UID=$(id -u) GID=$(id -g) docker compose run --rm build
 
-With system Go (needs 1.21+ so the `toolchain` directive can fetch 1.26):
+(The explicit `UID`/`GID` ensure the output binary is owned by you. Bash doesn't export them by default, so `compose.yml`'s `${UID:-1000}` substitution would otherwise silently fall back to `1000:1000`.)
+
+With system Go 1.21 or newer (the `go 1.26.1` directive in `go.mod` auto-downloads the matching toolchain on first build):
 
     go build .
 

--- a/README.md
+++ b/README.md
@@ -27,7 +27,11 @@ With Nix (recommended, no host pollution):
 
     nix develop --command go build .
 
-With system Go:
+With Docker (works anywhere `docker compose` does, pins the Go toolchain):
+
+    docker compose run --rm build
+
+With system Go (needs 1.21+ so the `toolchain` directive can fetch 1.26):
 
     go build .
 

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -1,0 +1,11 @@
+services:
+  build:
+    image: golang:1.26
+    user: "${UID:-1000}:${GID:-1000}"
+    working_dir: /src
+    volumes:
+      - .:/src
+    environment:
+      GOCACHE: /src/.cache/go-build
+      GOMODCACHE: /src/.cache/go-mod
+    command: go build -o agentpen .


### PR DESCRIPTION
Adds a `docker compose` build target so the Go binary can be built on any host with Docker, without needing a matching host Go toolchain or Nix.

## Why

`go.mod` pins `go 1.26.1`. Ubuntu 22.04's apt ships Go 1.18, so `go build .` fails with `invalid go version '1.26.1': must match format 1.23`. Previously the only supported paths were Nix (`nix develop --command go build .`) or a sufficiently fresh system Go. This commit adds a third option that works anywhere `docker compose` does.

## Changes

- `docker-compose.yml` — single `build` service on pinned `golang:1.26`. Runs as host `${UID:-1000}:${GID:-1000}` so the output binary isn't root-owned. Go module/build caches land in `.cache/` inside the repo for reuse across runs.
- `.gitignore` — ignore `/.cache/`.
- `README.md` — add the Docker build option alongside Nix / system Go.

## Scope note

This is a build on-ramp only. Dev and test still require a real Linux host — bwrap / netns / nftables / seccomp don't work meaningfully inside an unprivileged container — so this deliberately does not try to become a dev environment. The existing Nix dev shell and system `go build` paths are unchanged.

## Test Plan

- [x] `docker compose run --rm build` produces `./agentpen` owned by the invoking user.
- [x] `./agentpen --help` runs cleanly.
- [x] `./agentpen --check` reports all seven required layers available on Ubuntu 22.04 + HWE 6.8 kernel.
- [ ] Rerun on a clean machine with only Docker installed to confirm zero host dependencies beyond `docker compose`.
