### PR TITLE
resolve user-local agent installs on FHS hosts

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -65,6 +65,14 @@ func bwrapArgs(cfg runConfig, stageEtcPath string) []string {
 	if err != nil {
 		shell = "/bin/sh"
 	}
+	// Follow the standard Linux .profile convention: ~/.local/bin wins over
+	// system dirs when present. Lets user-local agent installs be found by
+	// name inside the sandbox (the binary itself is bound via auto-mount).
+	pathEnv := layout.PathEnv
+	userLocalBin := filepath.Join(cfg.Home, ".local", "bin")
+	if info, err := os.Stat(userLocalBin); err == nil && info.IsDir() {
+		pathEnv = userLocalBin + ":" + pathEnv
+	}
 	args := []string{
 		"--unshare-user", "--unshare-ipc", "--unshare-pid", "--unshare-uts", "--unshare-cgroup",
 		"--die-with-parent", "--new-session", "--hostname", "agentpen",
@@ -74,7 +82,7 @@ func bwrapArgs(cfg runConfig, stageEtcPath string) []string {
 		"--setenv", "LOGNAME", cfg.User,
 		"--setenv", "SHELL", shell,
 		"--setenv", "TERM", orDefault(os.Getenv("TERM"), "xterm-256color"),
-		"--setenv", "PATH", layout.PathEnv,
+		"--setenv", "PATH", pathEnv,
 		"--setenv", "LANG", orDefault(os.Getenv("LANG"), "C.UTF-8"),
 		"--proc", "/proc",
 		"--dev", "/dev",

--- a/fs.go
+++ b/fs.go
@@ -96,6 +96,14 @@ func bwrapArgs(cfg runConfig, stageEtcPath string) []string {
 			args = append(args, "--ro-bind", p, p)
 		}
 	}
+	// Auto-mounts (from resolveCommand) bind RO before the project dir and any
+	// explicit RW mounts — bwrap is order-sensitive, so later RW binds override
+	// here if a caller invokes a binary from inside the project dir.
+	for _, p := range cfg.AutoMounts {
+		if _, err := os.Stat(p); err == nil {
+			args = append(args, "--ro-bind", p, p)
+		}
+	}
 	args = append(args, "--bind", cfg.ProjectDir, cfg.ProjectDir, "--chdir", cfg.ProjectDir)
 
 	// Forward env vars that are set on the host

--- a/main.go
+++ b/main.go
@@ -157,6 +157,16 @@ func run() error {
 		return fmt.Errorf("refusing to use %s as project dir", projectDir)
 	}
 
+	// Resolve the agent binary on the host before the sandbox starts: follow
+	// symlinks and collect any dirs that need to be bound so the binary stays
+	// reachable inside (user-local installs like ~/.local/bin/claude → ~/.local/share/...
+	// would otherwise vanish with the tmpfs'd $HOME).
+	layout := detectHostLayout()
+	resolvedCmd, autoMounts, err := resolveCommand(command, layout)
+	if err != nil {
+		return err
+	}
+
 	// Merge registry + user-supplied
 	cfg := runConfig{
 		Profile:       profile,
@@ -164,9 +174,9 @@ func run() error {
 		ProjectDir:    projectDir,
 		Home:          home,
 		User:          user,
-		Command:       command,
-		HostLayout:    detectHostLayout(),
-		ExtraROMounts: mountRO,
+		Command:       resolvedCmd,
+		HostLayout:    layout,
+		ExtraROMounts: append(mountRO, autoMounts...),
 		ExtraRWMounts: mountRW,
 	}
 	if agent != "" {

--- a/main.go
+++ b/main.go
@@ -29,6 +29,7 @@ type runConfig struct {
 	Mounts        []string
 	ExtraROMounts []string
 	ExtraRWMounts []string
+	AutoMounts    []string
 	Command       []string
 	HostLayout    HostLayout
 }
@@ -176,8 +177,9 @@ func run() error {
 		User:          user,
 		Command:       resolvedCmd,
 		HostLayout:    layout,
-		ExtraROMounts: append(mountRO, autoMounts...),
+		ExtraROMounts: mountRO,
 		ExtraRWMounts: mountRW,
+		AutoMounts:    autoMounts,
 	}
 	if agent != "" {
 		a := agents[agent]

--- a/resolve.go
+++ b/resolve.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"fmt"
+	"os/exec"
+	"path/filepath"
+	"strings"
+)
+
+// resolveCommand looks up cmd[0] on the host PATH (when not already a path),
+// follows symlinks to the real binary, and reports any directories the
+// sandbox must bind RO so both the invocation path and its target are
+// reachable inside.
+//
+// Why: user-local installs on FHS distros (e.g., the native Claude installer
+// puts the binary at ~/.local/bin/claude → ~/.local/share/claude/versions/X)
+// would otherwise disappear when the sandbox tmpfs's $HOME. The NixOS layout
+// bind-mounts /nix/store, so this was invisible until FHS hosts arrived.
+func resolveCommand(cmd []string, layout HostLayout) ([]string, []string, error) {
+	if len(cmd) == 0 {
+		return nil, nil, fmt.Errorf("empty command")
+	}
+	bin := cmd[0]
+	if !strings.Contains(bin, "/") {
+		resolved, err := exec.LookPath(bin)
+		if err != nil {
+			return nil, nil, fmt.Errorf("%q not found on PATH", bin)
+		}
+		bin = resolved
+	}
+	absBin, err := filepath.Abs(bin)
+	if err != nil {
+		return nil, nil, fmt.Errorf("abs %s: %w", bin, err)
+	}
+	real, err := filepath.EvalSymlinks(absBin)
+	if err != nil {
+		return nil, nil, fmt.Errorf("resolve symlinks for %s: %w", absBin, err)
+	}
+
+	seen := map[string]bool{}
+	var extras []string
+	for _, d := range []string{filepath.Dir(absBin), filepath.Dir(real)} {
+		d = filepath.Clean(d)
+		if seen[d] || coveredBy(d, layout.ReadOnlyBinds) {
+			continue
+		}
+		seen[d] = true
+		extras = append(extras, d)
+	}
+
+	return append([]string{absBin}, cmd[1:]...), extras, nil
+}
+
+// coveredBy reports whether path is inside or equal to any of prefixes,
+// respecting path boundaries (so "/usrlib" is not "covered" by "/usr").
+func coveredBy(path string, prefixes []string) bool {
+	path = filepath.Clean(path)
+	for _, p := range prefixes {
+		p = filepath.Clean(p)
+		if path == p || strings.HasPrefix(path, p+"/") {
+			return true
+		}
+	}
+	return false
+}

--- a/resolve_test.go
+++ b/resolve_test.go
@@ -1,0 +1,90 @@
+package main
+
+import (
+	"os"
+	"path/filepath"
+	"reflect"
+	"sort"
+	"testing"
+)
+
+func TestCoveredBy(t *testing.T) {
+	prefixes := []string{"/usr", "/bin", "/nix/store"}
+	cases := map[string]bool{
+		"/usr/bin":                  true,
+		"/usr":                      true,
+		"/bin/bash":                 true,
+		"/nix/store/abc-foo/bin":    true,
+		"/usrlib":                   false, // boundary: "/usrlib" is not under "/usr"
+		"/home/alice/.local/bin":    false,
+		"/opt/tool":                 false,
+	}
+	for path, want := range cases {
+		if got := coveredBy(path, prefixes); got != want {
+			t.Errorf("coveredBy(%q) = %v, want %v", path, got, want)
+		}
+	}
+}
+
+func TestResolveCommand_SymlinkToUserLocal(t *testing.T) {
+	// Build a synthetic user-local install: $TMP/bin/tool -> $TMP/share/tool/versions/X
+	tmp := t.TempDir()
+	binDir := filepath.Join(tmp, "bin")
+	shareDir := filepath.Join(tmp, "share", "tool", "versions")
+	if err := os.MkdirAll(binDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	if err := os.MkdirAll(shareDir, 0755); err != nil {
+		t.Fatal(err)
+	}
+	real := filepath.Join(shareDir, "1.0.0")
+	if err := os.WriteFile(real, []byte("#!/bin/sh\n"), 0755); err != nil {
+		t.Fatal(err)
+	}
+	link := filepath.Join(binDir, "tool")
+	if err := os.Symlink(real, link); err != nil {
+		t.Fatal(err)
+	}
+
+	layout := HostLayout{ReadOnlyBinds: []string{"/usr", "/bin", "/lib", "/lib64"}}
+
+	// Invoke by absolute path: must rewrite to absBin and auto-mount both parents.
+	got, mounts, err := resolveCommand([]string{link, "--flag"}, layout)
+	if err != nil {
+		t.Fatalf("resolveCommand: %v", err)
+	}
+	wantCmd := []string{link, "--flag"}
+	if !reflect.DeepEqual(got, wantCmd) {
+		t.Errorf("command = %v, want %v", got, wantCmd)
+	}
+	sort.Strings(mounts)
+	wantMounts := []string{binDir, shareDir}
+	sort.Strings(wantMounts)
+	if !reflect.DeepEqual(mounts, wantMounts) {
+		t.Errorf("mounts = %v, want %v", mounts, wantMounts)
+	}
+}
+
+func TestResolveCommand_SystemBinary(t *testing.T) {
+	// A binary under a covered layout dir should produce zero auto-mounts.
+	layout := HostLayout{ReadOnlyBinds: []string{"/usr", "/bin"}}
+	// Use /bin/sh; present on every Linux box CI would run on.
+	got, mounts, err := resolveCommand([]string{"sh"}, layout)
+	if err != nil {
+		t.Skipf("sh not on PATH in this env: %v", err)
+	}
+	if !filepath.IsAbs(got[0]) {
+		t.Errorf("command[0] not absolute: %q", got[0])
+	}
+	if len(mounts) != 0 {
+		t.Errorf("expected no auto-mounts for system binary, got %v", mounts)
+	}
+}
+
+func TestResolveCommand_NotOnPath(t *testing.T) {
+	layout := HostLayout{}
+	_, _, err := resolveCommand([]string{"definitely-not-a-real-binary-zzz"}, layout)
+	if err == nil {
+		t.Fatal("expected error for missing binary, got nil")
+	}
+}


### PR DESCRIPTION
Fixes `bwrap: execvp claude: No such file or directory` when the agent binary lives under `$HOME` on FHS distros — the case triggered by the new Claude native installer on Ubuntu, which puts the binary at `~/.local/bin/claude` → `~/.local/share/claude/versions/X`.

## Root cause

The sandbox tmpfs's `$HOME` (`fs.go:83`), so anything under it vanishes inside the sandbox. NixOS wasn't hit because binaries live under `/nix/store`, which `host.go` bind-mounts RO. On FHS hosts the HostLayout binds `/usr /bin /sbin /lib /lib64` only — user-local installs fall off the edge.

Two related gaps:

1. `command[0]` was passed verbatim to bwrap. When the binary wasn't on the sandbox's view of the filesystem, `execvp` failed.
2. The hardcoded FHS PATH (`host.go:24`) didn't include `~/.local/bin`, so even a mounted binary wouldn't be found by name.

## Changes

- **`resolve.go` (new)** — `resolveCommand` looks up `cmd[0]` on the host PATH, follows symlinks to the real target, and returns both the rewritten (absolute) command and any directories that need to be bound RO so the invocation path and the symlink target are reachable. Already-covered dirs (under `HostLayout.ReadOnlyBinds`) are skipped. `coveredBy` respects path boundaries so `/usrlib` isn't treated as inside `/usr`.
- **`main.go`** — call `resolveCommand` after projectDir resolution; append the auto-mounts to `ExtraROMounts`; feed the rewritten command to `cfg`.
- **`fs.go`** — prepend `$HOME/.local/bin` to the sandbox PATH when the dir exists on the host. Matches the standard `.profile` convention that Ubuntu/Debian/Fedora all ship.
- **`resolve_test.go` (new)** — first tests in the repo. Covers the symlink-to-user-local case, the already-covered system-binary case (zero auto-mounts), and the missing-binary error. Run with `docker compose run --rm --user "$(id -u):$(id -g)" build go test ./...`.

## Scope notes

- Only handles the case where the **binary itself** is user-local. An agent that's a wrapper script invoking another user-local runtime (e.g., a shell script calling `~/.nvm/.../node`) would need additional mounts. The `--mount` flag remains the escape hatch.
- Doesn't touch the agent registry in `agents.go`. The fix is installer-layout agnostic — npm-global, native installer, pipx, manual tarball all go through the same resolution.

## Test Plan

- [x] `go test ./...` — resolve_test.go passes.
- [x] `go vet ./...` clean.
- [x] `go build .` produces the binary.
- [ ] `./agentpen claude` end-to-end on Ubuntu 22.04 with the native Claude installer — should no longer hit `execvp: No such file or directory`.
- [ ] `./agentpen claude` on NixOS (the original dogfood path) — should behave identically to before, since the NixOS HostLayout covers `/nix/store` and no auto-mount should be generated.

## Known follow-up

The previous PR's README asks users to run `UID=$(id -u) GID=$(id -g) docker compose run …`, which fails in bash because `UID` is a readonly shell variable. The correct invocation is `docker compose run --rm --user "$(id -u):$(id -g)" build`. Will fix in a separate PR so this one stays scoped.
