### PR TITLE
harden netns isolation: per-session subnet, auto-reap, fast reject

### DIFF
--- a/main.go
+++ b/main.go
@@ -224,9 +224,11 @@ func run() error {
 		return fmt.Errorf("sudo: %w", err)
 	}
 
-	// Auto-reap orphans from crashed/killed prior runs. Silent on nothing,
-	// short notice when it cleans anything so the user knows it happened.
-	if reaped, _ := reapOrphans(); len(reaped) > 0 {
+	// Auto-reap orphans from crashed/killed prior runs. Surface listing errors
+	// as warnings but proceed — a failed reap shouldn't block a new run.
+	if reaped, err := reapOrphans(); err != nil {
+		fmt.Fprintf(os.Stderr, "agentpen: auto-reap skipped: %v\n", err)
+	} else if len(reaped) > 0 {
 		fmt.Fprintf(os.Stderr, "agentpen: reaped %d leaked namespace(s): %s\n",
 			len(reaped), strings.Join(reaped, " "))
 	}
@@ -234,7 +236,7 @@ func run() error {
 	// Netns setup
 	ns := newNetns(os.Getpid())
 	cleanup := func() {
-		ns.teardown()
+		_ = ns.teardown()
 	}
 	defer cleanup()
 	// Also clean on signal

--- a/main.go
+++ b/main.go
@@ -8,7 +8,6 @@ import (
 	"os/signal"
 	"path/filepath"
 	"sort"
-	"strconv"
 	"strings"
 	"syscall"
 )
@@ -39,6 +38,7 @@ func usage() {
 	sort.Strings(known)
 	fmt.Fprintf(os.Stderr, `usage: agentpen [options] [--] <command> [args...]
        agentpen --check
+       agentpen --reap
 
 Runs <command> inside a confined sandbox (bwrap + netns + nftables + seccomp).
 
@@ -51,6 +51,7 @@ options:
   --mount-rw PATH  extra read-write bind mount (repeatable)
   --project DIR    project dir, bound RW (default: $PWD)
   --check          report which sandbox layers this host can enforce and exit
+  --reap           tear down leaked ap-* netns from crashed/killed prior runs
   -h, --help       show this help
 
 known agents: %s
@@ -74,6 +75,7 @@ func run() error {
 		mountRO    stringList
 		mountRW    stringList
 		check      bool
+		reap       bool
 	)
 
 	fs := flag.NewFlagSet("agentpen", flag.ContinueOnError)
@@ -86,6 +88,7 @@ func run() error {
 	fs.Var(&mountRO, "mount", "")
 	fs.Var(&mountRW, "mount-rw", "")
 	fs.BoolVar(&check, "check", false, "")
+	fs.BoolVar(&reap, "reap", false, "")
 
 	if err := fs.Parse(os.Args[1:]); err != nil {
 		if err == flag.ErrHelp {
@@ -97,6 +100,23 @@ func run() error {
 	// --check: report capabilities and exit without running anything
 	if check {
 		fmt.Print(detectCapabilities().Report(profile))
+		return nil
+	}
+
+	// --reap: tear down leaked namespaces from prior crashed/killed runs
+	if reap {
+		if err := sudoRun("-v"); err != nil {
+			return fmt.Errorf("sudo: %w", err)
+		}
+		reaped, err := reapOrphans()
+		if err != nil {
+			return err
+		}
+		if len(reaped) == 0 {
+			fmt.Println("no orphaned agentpen namespaces found")
+		} else {
+			fmt.Printf("reaped %d orphan(s): %s\n", len(reaped), strings.Join(reaped, " "))
+		}
 		return nil
 	}
 
@@ -204,8 +224,15 @@ func run() error {
 		return fmt.Errorf("sudo: %w", err)
 	}
 
+	// Auto-reap orphans from crashed/killed prior runs. Silent on nothing,
+	// short notice when it cleans anything so the user knows it happened.
+	if reaped, _ := reapOrphans(); len(reaped) > 0 {
+		fmt.Fprintf(os.Stderr, "agentpen: reaped %d leaked namespace(s): %s\n",
+			len(reaped), strings.Join(reaped, " "))
+	}
+
 	// Netns setup
-	ns := newNetns(strconv.Itoa(os.Getpid()))
+	ns := newNetns(os.Getpid())
 	cleanup := func() {
 		ns.teardown()
 	}

--- a/network.go
+++ b/network.go
@@ -5,6 +5,7 @@ import (
 	"net"
 	"os"
 	"os/exec"
+	"strconv"
 	"strings"
 )
 
@@ -18,12 +19,22 @@ type Netns struct {
 	VethS  string
 }
 
-func newNetns(suffix string) Netns {
+// newNetns derives a per-session /24 from the pid's third octet so two
+// concurrent agentpen runs don't both claim 10.200.99.0/24 — the host would
+// end up with two directly-connected routes for the same subnet and reply
+// packets would coin-flip between the veths. 254 buckets is plenty for any
+// realistic concurrency on a workstation; collision across generations is
+// naturally resolved by the startup reaper (dead session's netns gets torn
+// down before a new one tries the same octet).
+func newNetns(pid int) Netns {
+	octet := (pid % 254) + 1
+	prefix := fmt.Sprintf("10.200.%d", octet)
+	suffix := strconv.Itoa(pid)
 	return Netns{
 		Name:   "ap-" + suffix,
-		HostIP: "10.200.99.1",
-		SbxIP:  "10.200.99.2",
-		Subnet: "10.200.99.0/24",
+		HostIP: prefix + ".1",
+		SbxIP:  prefix + ".2",
+		Subnet: prefix + ".0/24",
 		VethH:  "vh-" + suffix,
 		VethS:  "vs-" + suffix,
 	}
@@ -87,6 +98,10 @@ func (n *Netns) loadNft(allowedIPs []string) error {
 	for _, ip := range allowedIPs {
 		fmt.Fprintf(&b, "        ip daddr %s accept\n", ip)
 	}
+	// Reject non-allowed TCP with RST so callers fail in milliseconds instead
+	// of sitting in the kernel's ~75s SYN-retry window. Non-TCP falls through
+	// to policy drop (DNS is already blocked at resolv.conf, so rare).
+	b.WriteString("        meta l4proto tcp reject with tcp reset\n")
 	b.WriteString("    }\n")
 	b.WriteString("}\n")
 
@@ -109,6 +124,45 @@ func (n *Netns) teardown() {
 	_ = sudoRunQuiet("ip", "netns", "del", n.Name)
 	_ = sudoRunQuiet("ip", "link", "del", n.VethH)
 	_ = sudoRunQuiet("iptables", "-t", "nat", "-D", "POSTROUTING", "-s", n.Subnet, "-j", "MASQUERADE")
+}
+
+// reapOrphans walks `ip netns list`, finds any `ap-<pid>` namespaces whose
+// owning process no longer exists, and tears them down (netns + host veth +
+// MASQUERADE rule). Required because defer-based teardown doesn't run on
+// SIGKILL, power loss, or panic — leaked veths with duplicate IPs on the
+// host would otherwise break the next session's return-path routing.
+//
+// Caller must have a valid sudo ticket. Silent on success; returns the list
+// of reaped names for the caller to log if desired.
+func reapOrphans() ([]string, error) {
+	out, err := exec.Command("ip", "netns", "list").Output()
+	if err != nil {
+		// No netns support, no permissions, or empty — nothing to reap.
+		return nil, nil
+	}
+	var reaped []string
+	for _, line := range strings.Split(string(out), "\n") {
+		fields := strings.Fields(line)
+		if len(fields) == 0 {
+			continue
+		}
+		name := fields[0]
+		if !strings.HasPrefix(name, "ap-") {
+			continue
+		}
+		pid, err := strconv.Atoi(strings.TrimPrefix(name, "ap-"))
+		if err != nil {
+			continue
+		}
+		// /proc/<pid> exists for any live process; absent means dead.
+		if _, err := os.Stat(fmt.Sprintf("/proc/%d", pid)); err == nil {
+			continue
+		}
+		ns := newNetns(pid)
+		ns.teardown()
+		reaped = append(reaped, name)
+	}
+	return reaped, nil
 }
 
 // sudoRun runs `sudo <args...>` with inherited stdio.

--- a/network.go
+++ b/network.go
@@ -162,10 +162,14 @@ func parseOrphanCandidates(listing string) []int {
 	return pids
 }
 
-// isAgentpenAlive returns true iff /proc/<pid>/comm reads as "agentpen".
-// Returning true on ambiguous errors (hidepid, transient I/O) is the
-// fail-safe choice — better to leak a namespace than wrongly tear down a
-// live session. Only treats os.ErrNotExist as definitively dead.
+// isAgentpenAlive returns true iff /proc/<pid>/comm begins with "agentpen".
+// Prefix match (not equality) so renamed/symlinked builds like agentpen-dev
+// don't look "dead" to a concurrent session and get reaped. Kernel truncates
+// comm to 15 chars so "agentpen" always fits at the start.
+//
+// Returning true on ambiguous errors (hidepid, transient I/O) is the fail-safe
+// choice — better to leak a namespace than wrongly tear down a live session.
+// Only treats os.ErrNotExist as definitively dead.
 func isAgentpenAlive(pid int) bool {
 	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
 	if errors.Is(err, os.ErrNotExist) {
@@ -174,7 +178,7 @@ func isAgentpenAlive(pid int) bool {
 	if err != nil {
 		return true
 	}
-	return strings.TrimSpace(string(data)) == "agentpen"
+	return strings.HasPrefix(strings.TrimSpace(string(data)), "agentpen")
 }
 
 // reapOrphans walks `ip netns list`, finds any `ap-<pid>` namespaces whose
@@ -189,8 +193,11 @@ func isAgentpenAlive(pid int) bool {
 // namespaces whose teardown fully succeeded; per-namespace failures are
 // logged to stderr so partial reap is visible.
 func reapOrphans() ([]string, error) {
-	out, err := exec.Command("sudo", "-n", "ip", "netns", "list").Output()
+	out, err := exec.Command("sudo", "-n", "ip", "netns", "list").CombinedOutput()
 	if err != nil {
+		if msg := strings.TrimSpace(string(out)); msg != "" {
+			return nil, fmt.Errorf("list netns: %w: %s", err, msg)
+		}
 		return nil, fmt.Errorf("list netns: %w", err)
 	}
 	var reaped []string

--- a/network.go
+++ b/network.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"errors"
 	"fmt"
 	"net"
 	"os"
@@ -119,29 +120,31 @@ func (n *Netns) loadNft(allowedIPs []string) error {
 	return sudoRun("ip", "netns", "exec", n.Name, "nft", "-f", f.Name())
 }
 
-// teardown is best-effort and swallows errors (cleanup should never fail the run).
-func (n *Netns) teardown() {
-	_ = sudoRunQuiet("ip", "netns", "del", n.Name)
-	_ = sudoRunQuiet("ip", "link", "del", n.VethH)
-	_ = sudoRunQuiet("iptables", "-t", "nat", "-D", "POSTROUTING", "-s", n.Subnet, "-j", "MASQUERADE")
+// teardown removes the netns, host-side veth, and MASQUERADE rule. Returns
+// an aggregated error if any step failed; callers doing cleanup-on-exit
+// typically discard it, but the reaper uses it to avoid claiming success
+// on partial failures.
+func (n *Netns) teardown() error {
+	var errs []error
+	if err := sudoRunQuiet("ip", "netns", "del", n.Name); err != nil {
+		errs = append(errs, fmt.Errorf("del netns: %w", err))
+	}
+	if err := sudoRunQuiet("ip", "link", "del", n.VethH); err != nil {
+		errs = append(errs, fmt.Errorf("del veth: %w", err))
+	}
+	if err := sudoRunQuiet("iptables", "-t", "nat", "-D", "POSTROUTING",
+		"-s", n.Subnet, "-j", "MASQUERADE"); err != nil {
+		errs = append(errs, fmt.Errorf("del masquerade: %w", err))
+	}
+	return errors.Join(errs...)
 }
 
-// reapOrphans walks `ip netns list`, finds any `ap-<pid>` namespaces whose
-// owning process no longer exists, and tears them down (netns + host veth +
-// MASQUERADE rule). Required because defer-based teardown doesn't run on
-// SIGKILL, power loss, or panic — leaked veths with duplicate IPs on the
-// host would otherwise break the next session's return-path routing.
-//
-// Caller must have a valid sudo ticket. Silent on success; returns the list
-// of reaped names for the caller to log if desired.
-func reapOrphans() ([]string, error) {
-	out, err := exec.Command("ip", "netns", "list").Output()
-	if err != nil {
-		// No netns support, no permissions, or empty — nothing to reap.
-		return nil, nil
-	}
-	var reaped []string
-	for _, line := range strings.Split(string(out), "\n") {
+// parseOrphanCandidates extracts candidate pids from `ip netns list` output.
+// Skips blank lines, non-`ap-*` names, and `ap-*` names whose suffix isn't
+// an integer. Pure for easy testing.
+func parseOrphanCandidates(listing string) []int {
+	var pids []int
+	for _, line := range strings.Split(listing, "\n") {
 		fields := strings.Fields(line)
 		if len(fields) == 0 {
 			continue
@@ -154,13 +157,53 @@ func reapOrphans() ([]string, error) {
 		if err != nil {
 			continue
 		}
-		// /proc/<pid> exists for any live process; absent means dead.
-		if _, err := os.Stat(fmt.Sprintf("/proc/%d", pid)); err == nil {
+		pids = append(pids, pid)
+	}
+	return pids
+}
+
+// isAgentpenAlive returns true iff /proc/<pid>/comm reads as "agentpen".
+// Returning true on ambiguous errors (hidepid, transient I/O) is the
+// fail-safe choice — better to leak a namespace than wrongly tear down a
+// live session. Only treats os.ErrNotExist as definitively dead.
+func isAgentpenAlive(pid int) bool {
+	data, err := os.ReadFile(fmt.Sprintf("/proc/%d/comm", pid))
+	if errors.Is(err, os.ErrNotExist) {
+		return false
+	}
+	if err != nil {
+		return true
+	}
+	return strings.TrimSpace(string(data)) == "agentpen"
+}
+
+// reapOrphans walks `ip netns list`, finds any `ap-<pid>` namespaces whose
+// owning agentpen process no longer exists, and tears them down (netns +
+// host veth + MASQUERADE rule). Required because defer-based teardown
+// doesn't run on SIGKILL, power loss, or panic — leaked veths with
+// duplicate IPs on the host would otherwise break the next session's
+// return-path routing.
+//
+// Caller must have a valid sudo ticket. Runs the listing under sudo too,
+// since some hardened distros restrict /var/run/netns. Returns only
+// namespaces whose teardown fully succeeded; per-namespace failures are
+// logged to stderr so partial reap is visible.
+func reapOrphans() ([]string, error) {
+	out, err := exec.Command("sudo", "-n", "ip", "netns", "list").Output()
+	if err != nil {
+		return nil, fmt.Errorf("list netns: %w", err)
+	}
+	var reaped []string
+	for _, pid := range parseOrphanCandidates(string(out)) {
+		if isAgentpenAlive(pid) {
 			continue
 		}
 		ns := newNetns(pid)
-		ns.teardown()
-		reaped = append(reaped, name)
+		if err := ns.teardown(); err != nil {
+			fmt.Fprintf(os.Stderr, "agentpen: reap %s: %v\n", ns.Name, err)
+			continue
+		}
+		reaped = append(reaped, ns.Name)
 	}
 	return reaped, nil
 }

--- a/network_test.go
+++ b/network_test.go
@@ -1,12 +1,16 @@
 package main
 
 import (
+	"reflect"
 	"strconv"
 	"strings"
 	"testing"
 )
 
-func TestNewNetns_UniqueSubnetPerPid(t *testing.T) {
+func TestNewNetns_PidToSubnetBucketing(t *testing.T) {
+	// Maps pid → third octet via (pid%254)+1. Not globally unique (PIDs
+	// differing by 254 collide) — the reaper prevents cross-generation
+	// collisions in practice.
 	cases := []struct {
 		pid      int
 		wantOct  int
@@ -36,11 +40,48 @@ func TestNewNetns_UniqueSubnetPerPid(t *testing.T) {
 	}
 }
 
-func TestNewNetns_DistinctConcurrentPids(t *testing.T) {
-	// Two live sessions with different PIDs must land on different subnets.
+func TestNewNetns_AdjacentPidsDistinct(t *testing.T) {
+	// Adjacent pids must end up on different subnets — this is what actually
+	// matters in practice, since concurrent agentpen sessions started in the
+	// same shell/script will have near-sequential pids.
 	a := newNetns(1000)
 	b := newNetns(1001)
 	if a.Subnet == b.Subnet {
 		t.Fatalf("adjacent PIDs collided on %s", a.Subnet)
+	}
+}
+
+func TestParseOrphanCandidates(t *testing.T) {
+	cases := map[string]struct {
+		input string
+		want  []int
+	}{
+		"empty":         {input: "", want: nil},
+		"blank-lines":   {input: "\n\n\n", want: nil},
+		"single-plain":  {input: "ap-12345\n", want: []int{12345}},
+		"with-id-suffix": {
+			input: "ap-12345 (id: 10)\nap-99 (id: 4)\n",
+			want:  []int{12345, 99},
+		},
+		"mixed-non-ap": {
+			input: "default\nap-42 (id: 1)\nnetns-other\nap-7\n",
+			want:  []int{42, 7},
+		},
+		"malformed-suffix": {
+			input: "ap-notanumber\nap-\nap-123foo\nap-5\n",
+			want:  []int{5},
+		},
+		"trailing-whitespace": {
+			input: "  ap-9\t(id: 3)   \n",
+			want:  []int{9},
+		},
+	}
+	for name, c := range cases {
+		t.Run(name, func(t *testing.T) {
+			got := parseOrphanCandidates(c.input)
+			if !reflect.DeepEqual(got, c.want) {
+				t.Errorf("parseOrphanCandidates() = %v, want %v", got, c.want)
+			}
+		})
 	}
 }

--- a/network_test.go
+++ b/network_test.go
@@ -1,0 +1,46 @@
+package main
+
+import (
+	"strconv"
+	"strings"
+	"testing"
+)
+
+func TestNewNetns_UniqueSubnetPerPid(t *testing.T) {
+	cases := []struct {
+		pid      int
+		wantOct  int
+		wantName string
+	}{
+		{1, 2, "ap-1"},
+		{99, 100, "ap-99"},
+		{253, 254, "ap-253"},
+		{254, 1, "ap-254"}, // wraps
+		{12345, (12345 % 254) + 1, "ap-12345"},
+	}
+	for _, c := range cases {
+		ns := newNetns(c.pid)
+		if ns.Name != c.wantName {
+			t.Errorf("pid %d: Name = %q, want %q", c.pid, ns.Name, c.wantName)
+		}
+		wantPrefix := "10.200." + strconv.Itoa(c.wantOct) + "."
+		if !strings.HasPrefix(ns.Subnet, wantPrefix) {
+			t.Errorf("pid %d: Subnet = %q, want prefix %q", c.pid, ns.Subnet, wantPrefix)
+		}
+		if ns.HostIP != wantPrefix+"1" {
+			t.Errorf("pid %d: HostIP = %q, want %s1", c.pid, ns.HostIP, wantPrefix)
+		}
+		if ns.SbxIP != wantPrefix+"2" {
+			t.Errorf("pid %d: SbxIP = %q, want %s2", c.pid, ns.SbxIP, wantPrefix)
+		}
+	}
+}
+
+func TestNewNetns_DistinctConcurrentPids(t *testing.T) {
+	// Two live sessions with different PIDs must land on different subnets.
+	a := newNetns(1000)
+	b := newNetns(1001)
+	if a.Subnet == b.Subnet {
+		t.Fatalf("adjacent PIDs collided on %s", a.Subnet)
+	}
+}


### PR DESCRIPTION
Three related netns robustness bugs surfaced while debugging a hang on Ubuntu with Docker installed. The user-visible symptom was "agentpen hangs for ~75s, sometimes recovers, sometimes works, sometimes doesn't." Root cause was a leaked namespace from a prior SIGKILL'd run colliding with the new session's subnet; the other two fixes are related hardening in the same vein.

## 1. Per-session `/24`

`newNetns` hardcoded `10.200.99.0/24`. Two concurrent runs (or, more commonly, a live run alongside leaked state from a killed one) put two host-side veths on the same subnet. The host then has two directly-connected routes for `10.200.99.0/24` and reply packets coin-flip between veths — one path dead-ends in the dead netns, the other works. Classic intermittent-hang signature.

Fix: derive the third octet from `pid%254+1` so each session gets its own subnet. 254 buckets is plenty for any realistic workstation concurrency, and the reaper (see #2) prevents long-term collision across generations.

## 2. Auto-reap + `--reap`

`defer ns.teardown()` doesn't run on SIGKILL, crashes, or power loss, leaving orphan `ap-<pid>` netns + `vh-<pid>` veth + duplicate `MASQUERADE` rules. Even with per-session subnets (#1), the old leaked `10.200.99.0/24` state would still be around and could be hit by new runs that happen to land on 99.

`reapOrphans` walks `ip netns list`, finds any `ap-<pid>` whose `/proc/<pid>` is absent (process no longer exists), and tears down its full state via the existing `teardown()`. Runs automatically after the startup sudo ticket is acquired, so most users never notice. `--reap` also exposes it as a manual subcommand for explicit cleanup.

## 3. DROP → REJECT with tcp-reset (for TCP)

With `policy drop`, blocked connections sit in the kernel's ~75s SYN-retry window (initial send + 5 retries at roughly 1, 3, 7, 15, 31s), which is indistinguishable from "the sandbox is hung." Inserting `meta l4proto tcp reject with tcp reset` before the policy-drop fallback fails TCP in milliseconds with a clean connection-refused at the client. Non-TCP still hits policy drop — DNS is already blocked at `resolv.conf` so the non-TCP path rarely matters.

Doesn't hide the sandbox from external scanners because the filter is in the netns's `output` hook (host egress from a sandboxed process), not an inbound public-facing filter — the "DROP hides us" argument doesn't apply.

## Changes

- `network.go` — `newNetns(pid int)` now takes an int and computes the per-pid subnet; nft ruleset gets a `meta l4proto tcp reject with tcp reset` rule; `reapOrphans()` added.
- `main.go` — `--reap` flag wired to usage and run-path; auto-reap after sudo ticket acquired on normal runs; `strconv` import no longer needed here.
- `network_test.go` (new) — covers per-pid subnet derivation, wrap at 254, and that adjacent pids land on distinct subnets.

## Test Plan

- [x] `go vet ./...` clean.
- [x] `go test ./...` — network_test.go passes.
- [x] `go build -o agentpen .` produces the binary.
- [x] `./agentpen --help` shows the new `--reap` line.
- [ ] `./agentpen --reap` on a box with no orphans → prints "no orphaned agentpen namespaces found".
- [ ] Kill an in-progress `./agentpen claude` with `pkill -KILL`, confirm `ip netns list | grep ap-` shows the leak, then `./agentpen claude` again → auto-reap message appears and the new run works without the subnet collision hang.
- [ ] Invoke the sandbox and try to reach a non-allowlisted HTTPS host from inside; confirm immediate connection refused instead of a 75s hang.
