### PR TITLE
silence pasta's /proc/net auto-port-forward scan

### DIFF
--- a/network.go
+++ b/network.go
@@ -16,6 +16,12 @@ import (
 //   namespace reach the host's loopback (where the SNI proxy listens).
 // --no-dhcp / --no-ndp / --no-dhcpv6 / --no-ra: suppress all auto-config;
 //   we set everything by hand inside the namespace for determinism.
+// -t/-u/-T/-U none: disable pasta's auto port-forwarding. Defaults are
+//   `auto`, which scans /proc/net/{tcp,tcp6,udp,udp6} for bound ports —
+//   that scan logs `lseek() failed on /proc/net file: Illegal seek` once
+//   per probe on older kernels (e.g. Ubuntu 22.04). We don't want any
+//   forwarding anyway: the in-namespace forwarder + nft handle inbound,
+//   and nothing in the namespace should be reachable from the host.
 // -q: don't print pasta's startup banner on every run.
 // -f: foreground; pasta exits when its child does, which we want for clean
 //   teardown of the namespace and the in-namespace forwarder.
@@ -23,6 +29,7 @@ func pastaArgs(proxyPort int, selfPath string, bwrapArgv []string) []string {
 	args := []string{
 		"-q", "-f",
 		"--no-dhcp", "--no-dhcpv6", "--no-ndp", "--no-ra",
+		"-t", "none", "-u", "none", "-T", "none", "-U", "none",
 		// Don't pin the namespace interface name — pasta names the tap after
 		// the host's outbound interface (eno1, enp3s0, wlan0, eth0, …) and
 		// we discover whatever it picked from inside the namespace at runtime.


### PR DESCRIPTION
Silence pasta's `/proc/net` auto-port-forward scan, which floods stderr with `lseek() failed on /proc/net file: Illegal seek` on Ubuntu 22.04.

## Changes
- Pass `-t none -u none -T none -U none` to pasta. Defaults are `auto`, which scans `/proc/net/{tcp,tcp6,udp,udp6}` for bound ports — that scan logs `lseek() failed on /proc/net file: Illegal seek` once per probe on older kernels (e.g. Ubuntu 22.04), producing ~12 stderr lines per invocation.
- We don't want auto-forwarding in either direction anyway: the in-namespace forwarder + nft handle inbound, and nothing in the namespace should be reachable from the host.

## Test plan
- [x] `go build ./... && go vet ./... && go test ./...` clean on NixOS
- [x] Smoke test on NixOS: `agentpen --allow api.anthropic.com -- curl ... https://api.anthropic.com/` returns `http=404 ssl=1`, stderr quiet (this kernel didn't emit the lseek lines anyway; regression check only)
- [ ] Confirm on Ubuntu 22 host that the `lseek()` lines are gone
