### PR TITLE
add codex ChatGPT-login hosts to allowlist

### DIFF
--- a/agents.go
+++ b/agents.go
@@ -13,7 +13,10 @@ var agents = map[string]Agent{
 		Mounts:       []string{"~/.claude", "~/.claude.json"},
 	},
 	"codex": {
-		AllowedHosts: []string{"api.openai.com"},
+		// chatgpt.com is the streaming endpoint when codex is authenticated via
+		// ChatGPT login (the default for most users); api.openai.com is the API-key
+		// path; auth.openai.com handles the OAuth flow for ChatGPT login.
+		AllowedHosts: []string{"api.openai.com", "chatgpt.com", "auth.openai.com"},
 		EnvVars:      []string{"OPENAI_API_KEY", "OPENAI_BASE_URL"},
 		Mounts:       []string{"~/.codex", "~/.config/codex"},
 	},


### PR DESCRIPTION
codex's allowlist had only `api.openai.com`, which is the API-key path. Most users now run codex authenticated via ChatGPT login, where it streams from `chatgpt.com/backend-api/codex/responses` and bounces through `auth.openai.com` for OAuth. Without those, every request died with `stream disconnected before completion`.

Verified working: `agentpen codex` in a separate dir successfully reaches the streaming endpoint and serves replies.

## Changes
- `agents.go`: add `chatgpt.com` and `auth.openai.com` to the codex agent's `AllowedHosts`.

## Test Plan
- [x] `go vet ./...` clean
- [x] `go test ./...` pass
- [x] `agentpen codex` round-trips a prompt end-to-end (streaming response received)
