### PR TITLE
run sandboxed process as real host uid/gid, not userns root

### DIFF
--- a/fs.go
+++ b/fs.go
@@ -6,6 +6,7 @@ import (
 	"os"
 	"os/exec"
 	"path/filepath"
+	"strconv"
 	"strings"
 )
 
@@ -63,6 +64,11 @@ func bwrapArgs(cfg runConfig, stageEtcPath string) []string {
 	args := []string{
 		"--unshare-user", "--unshare-ipc", "--unshare-pid", "--unshare-uts", "--unshare-cgroup",
 		"--die-with-parent", "--new-session", "--hostname", "agentpen",
+		// Pasta puts us in a userns where we're uid 0; without --uid, bwrap
+		// preserves that, and agents like `claude --dangerously-skip-permissions`
+		// refuse to run as root. Map back to the real host uid/gid.
+		"--uid", strconv.Itoa(os.Getuid()),
+		"--gid", strconv.Itoa(os.Getgid()),
 		"--clearenv",
 		"--setenv", "HOME", cfg.Home,
 		"--setenv", "USER", cfg.User,

--- a/fs_test.go
+++ b/fs_test.go
@@ -3,6 +3,7 @@ package main
 import (
 	"os"
 	"path/filepath"
+	"strconv"
 	"strings"
 	"testing"
 )
@@ -170,6 +171,50 @@ func TestBwrapArgs_CredentialsNotLeaked(t *testing.T) {
 				}
 			}
 		}
+	}
+}
+
+func TestBwrapArgs_MapsToHostUidGid(t *testing.T) {
+	// Pasta launches us in a userns where the caller is uid 0; without
+	// --uid/--gid bwrap preserves that root identity, which trips agent
+	// self-checks (e.g. claude --dangerously-skip-permissions). bwrapArgs
+	// must pass the real host uid/gid through, and they must appear before
+	// --clearenv so they're applied to the sandboxed process.
+	_, dirs := makeExistingDirs(t, "home/alice", "project", "etc")
+	home, project, etc := dirs[0], dirs[1], dirs[2]
+
+	cfg := runConfig{
+		ProjectDir: project,
+		Home:       home,
+		User:       "alice",
+		Command:    []string{"true"},
+	}
+	args := bwrapArgs(cfg, etc)
+
+	wantUID := strconv.Itoa(os.Getuid())
+	wantGID := strconv.Itoa(os.Getgid())
+	if !hasFlagPair(args, "--uid", wantUID) {
+		t.Errorf("missing --uid %s in args", wantUID)
+	}
+	if !hasFlagPair(args, "--gid", wantGID) {
+		t.Errorf("missing --gid %s in args", wantGID)
+	}
+
+	idxOf := func(flag string) int {
+		for i, a := range args {
+			if a == flag {
+				return i
+			}
+		}
+		return -1
+	}
+	uidIdx, gidIdx, clearIdx := idxOf("--uid"), idxOf("--gid"), idxOf("--clearenv")
+	if uidIdx < 0 || gidIdx < 0 || clearIdx < 0 {
+		t.Fatalf("flags missing: uid=%d gid=%d clearenv=%d", uidIdx, gidIdx, clearIdx)
+	}
+	if uidIdx > clearIdx || gidIdx > clearIdx {
+		t.Errorf("--uid/--gid must appear before --clearenv (uid=%d gid=%d clearenv=%d)",
+			uidIdx, gidIdx, clearIdx)
 	}
 }
 


### PR DESCRIPTION
Pasta launches the sandbox in a userns where the caller is uid 0. Without `--uid`, bwrap preserves that root identity inside its inner userns, so agent self-checks like `claude --dangerously-skip-permissions cannot be used with root/sudo privileges` (and the equivalent in codex) refuse to run.

Pass the real host uid/gid through to bwrap so the process inside the sandbox runs as the invoking user.

## Changes
- `fs.go`: add `--uid $HOST_UID --gid $HOST_GID` to the bwrap argv built in `bwrapArgs`.

## Test Plan
- [x] `go test ./...` passes
- [x] `./agentpen claude --dangerously-skip-permissions` no longer trips the root check
- [x] `./agentpen codex …` likewise works under its sudo/root check
- [x] inside the sandbox `id` reports the real host uid/gid instead of 0
