### PR TITLE
skip kernel pseudo-tunnels when picking pasta's tap

### DIFF
--- a/sandbox_init.go
+++ b/sandbox_init.go
@@ -140,22 +140,47 @@ func configureNetns() error {
 	return nil
 }
 
-// findSandboxIface returns the name of the non-loopback interface in the
-// current netns. Pasta creates exactly one tap and names it after the host's
-// outbound interface by default (eno1, enp3s0, eth0, wlan0, …) — host-
-// dependent, so we discover the name at runtime instead of hardcoding it.
+// findSandboxIface returns the name of pasta's tap interface in the current
+// netns. Pasta creates exactly one tap and names it after the host's outbound
+// interface by default (eno1, enp3s0, eth0, wlan0, …) — host-dependent, so we
+// discover the name at runtime instead of hardcoding it.
 func findSandboxIface() (string, error) {
 	ifs, err := net.Interfaces()
 	if err != nil {
 		return "", fmt.Errorf("list interfaces: %w", err)
 	}
+	return selectSandboxIface(ifs)
+}
+
+// selectSandboxIface picks pasta's tap out of an interface list. Pasta's tap
+// is a real ethernet device with a generated MAC; on some kernels (notably
+// when ip6_tunnel is built in or auto-loaded) fresh netnses also contain
+// pseudo-tunnels — ip6tnl0, tunl0, sit0, gre0, gretap0, ip6gre0 — which have
+// empty or all-zero hardware addresses. Filtering on a non-zero MAC selects
+// the tap deterministically without name-matching every kernel pseudo-dev.
+func selectSandboxIface(ifs []net.Interface) (string, error) {
 	for _, i := range ifs {
 		if i.Flags&net.FlagLoopback != 0 {
 			continue
 		}
+		if !hasRealHardwareAddr(i.HardwareAddr) {
+			continue
+		}
 		return i.Name, nil
 	}
-	return "", fmt.Errorf("no non-loopback interface in sandbox netns")
+	return "", fmt.Errorf("no pasta tap interface in sandbox netns")
+}
+
+func hasRealHardwareAddr(hw net.HardwareAddr) bool {
+	if len(hw) == 0 {
+		return false
+	}
+	for _, b := range hw {
+		if b != 0 {
+			return true
+		}
+	}
+	return false
 }
 
 // spawnForwarder launches `agentpen __forwarder` as a separate process and

--- a/sandbox_init_test.go
+++ b/sandbox_init_test.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"net"
 	"strings"
 	"testing"
 )
@@ -36,5 +37,69 @@ func TestEgressFilterRules_PortIsParameterized(t *testing.T) {
 	}
 	if strings.Contains(b, "tcp dport 8443") {
 		t.Error("port 9999 rule still mentions 8443 — likely a hardcoded leak")
+	}
+}
+
+func TestSelectSandboxIface(t *testing.T) {
+	lo := net.Interface{Name: "lo", Flags: net.FlagLoopback | net.FlagUp}
+	ip6tnl := net.Interface{Name: "ip6tnl0", Flags: net.FlagUp, HardwareAddr: net.HardwareAddr{}}
+	tunl := net.Interface{Name: "tunl0", Flags: net.FlagUp, HardwareAddr: net.HardwareAddr{0, 0, 0, 0}}
+	tap := net.Interface{Name: "wlp4s0", Flags: net.FlagUp, HardwareAddr: net.HardwareAddr{0xf6, 0x56, 0x4a, 0xa3, 0x7c, 0x8c}}
+	tap2 := net.Interface{Name: "eno1", Flags: net.FlagUp, HardwareAddr: net.HardwareAddr{0x52, 0x54, 0x00, 0x12, 0x34, 0x56}}
+
+	cases := []struct {
+		name    string
+		ifs     []net.Interface
+		want    string
+		wantErr bool
+	}{
+		{"only loopback", []net.Interface{lo}, "", true},
+		{"only pseudo-tunnel", []net.Interface{lo, ip6tnl}, "", true},
+		{"only zero-MAC tunl0", []net.Interface{lo, tunl}, "", true},
+		{"tap only", []net.Interface{lo, tap}, "wlp4s0", false},
+		{"pseudo before tap (the regression)", []net.Interface{lo, ip6tnl, tap}, "wlp4s0", false},
+		{"tap before pseudo", []net.Interface{lo, tap, ip6tnl}, "wlp4s0", false},
+		{"multiple pseudos then tap", []net.Interface{lo, ip6tnl, tunl, tap}, "wlp4s0", false},
+		{"tap named eno1", []net.Interface{lo, tap2}, "eno1", false},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			got, err := selectSandboxIface(tc.ifs)
+			if tc.wantErr {
+				if err == nil {
+					t.Fatalf("want error, got %q", got)
+				}
+				return
+			}
+			if err != nil {
+				t.Fatalf("unexpected error: %v", err)
+			}
+			if got != tc.want {
+				t.Errorf("got %q, want %q", got, tc.want)
+			}
+		})
+	}
+}
+
+func TestHasRealHardwareAddr(t *testing.T) {
+	cases := []struct {
+		name string
+		hw   net.HardwareAddr
+		want bool
+	}{
+		{"empty", net.HardwareAddr{}, false},
+		{"nil", nil, false},
+		{"all zero 6", net.HardwareAddr{0, 0, 0, 0, 0, 0}, false},
+		{"all zero 4", net.HardwareAddr{0, 0, 0, 0}, false},
+		{"real ethernet", net.HardwareAddr{0xf6, 0x56, 0x4a, 0xa3, 0x7c, 0x8c}, true},
+		{"only first byte set", net.HardwareAddr{0x02, 0, 0, 0, 0, 0}, true},
+		{"only last byte set", net.HardwareAddr{0, 0, 0, 0, 0, 0x01}, true},
+	}
+	for _, tc := range cases {
+		t.Run(tc.name, func(t *testing.T) {
+			if got := hasRealHardwareAddr(tc.hw); got != tc.want {
+				t.Errorf("got %v, want %v", got, tc.want)
+			}
+		})
 	}
 }


### PR DESCRIPTION
`findSandboxIface` returned the first non-loopback interface in the namespace, which assumed pasta's tap was the only one. On kernels where `ip6_tunnel` is built in or auto-loaded into fresh netnses, `ip6tnl0` shows up too with an all-zero MAC; if it enumerated first the address and gateway route got installed on it, the real tap stayed DOWN and bare, and every connection to the gateway silently timed out with no SNI proxy log to show why. A recent kernel upgrade flipped this on locally and made the bug reproducible.

## Changes

- Extract selection into `selectSandboxIface([]net.Interface)` and skip interfaces with empty / all-zero `HardwareAddr`. Pasta's tap has a real generated MAC; `ip6tnl0`, `tunl0`, `sit0`, `gre0`, `gretap0`, `ip6gre0` all have zero MACs, so this picks the tap deterministically without name-matching every kernel pseudo-dev.
- Table tests for the regression case (pseudo before tap), all-zero variants, and `hasRealHardwareAddr` edges.

## Repro / verification

Before, inside the sandbox on an affected kernel:

```
== ip link ==
lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
ip6tnl0@NONE     UNKNOWN        :: <NOARP,UP,LOWER_UP>
wlp4s0           DOWN           f6:56:4a:a3:7c:8c <BROADCAST,MULTICAST>
== ip route ==
192.0.2.1 dev ip6tnl0 scope link
```

After:

```
== ip link ==
lo               UNKNOWN        00:00:00:00:00:00 <LOOPBACK,UP,LOWER_UP>
ip6tnl0@NONE     DOWN           :: <NOARP>
wlp4s0           UNKNOWN        de:c3:ae:1a:51:7b <BROADCAST,MULTICAST,UP,LOWER_UP>
== ip route ==
192.0.2.1 dev wlp4s0 scope link
```

End-to-end: `agentpen --verbose --agent claude claude-raw -p ...` now produces `ALLOW sni="api.anthropic.com"` proxy lines and a normal model response; previously it timed out at TCP connect with the proxy log silent.

## Test plan

- [x] `go test ./...` passes
- [x] On the affected host, the route to the gateway lands on pasta's tap
- [x] One-shot `claude` call through the sandbox succeeds end-to-end
- [ ] Worth checking on a kernel where `ip6tnl0` doesn't appear that we still pick the tap (the `tap only` test covers this in unit form)
